### PR TITLE
Confirmando email

### DIFF
--- a/src/config/paymentservice.json
+++ b/src/config/paymentservice.json
@@ -23,10 +23,10 @@
               "examples": {
                 "user": {
                   "value": {
-                    "firstName": "Gustavo",
-                    "lastName": "Oliveira",
-                    "email": "gstvOliveira@gmail.com",
-                    "password": "123456@G"
+                    "firstName": "Gabriel",
+                    "lastName": "Lyra",
+                    "email": "jgabriellyra@hotmail.com",
+                    "password": "123456@Ga"
                   }
                 }
               }

--- a/src/config/paymentservice.json
+++ b/src/config/paymentservice.json
@@ -50,6 +50,39 @@
           }
         }
       }
+    },
+    "/users/confirm-email": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Confirma o e-mail utilizado no cadastro",
+        "description": "",
+        "parameters": [{
+            "name": "authorization",
+            "in": "query",
+            "description": "Token para validar e-mail utilizado no cadastro",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }],
+        "responses": {
+          "200": {
+            "description": "E-mail confirmado com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Token inválido!"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -74,6 +107,21 @@
             "type": "string"
           }
         }
+      },
+      "Token": {
+        "type": "string",
+        "properties": {
+          "token": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     }
   }

--- a/src/controller/UserController.ts
+++ b/src/controller/UserController.ts
@@ -27,4 +27,9 @@ export default class UserController {
             return res.status(HttpCodes.BAD_REQUEST).json({ message: error.message })
         }
     }
+
+    async confirmEmail(_req: Request, res: Response) {
+        return res.status(HttpCodes.OK).json({ message: 'E-mail confirmado com sucesso!' })
+    }
+
 }

--- a/src/middlewares/remove.token.ts
+++ b/src/middlewares/remove.token.ts
@@ -1,12 +1,14 @@
 import { header } from "express-validator"
 import TokenService from "../service/TokenService"
-import { verify } from "jsonwebtoken";
 
 export const removeToken = () => (
-    header('authorization').isJWT().custom(async value => {
-        const token = new TokenService().getToken(value);
-        if (token) {
-            new TokenService().removeToken(token);
+    [header('authorization').isJWT().custom(async value => {
+        const { token } = await new TokenService().getToken(value);
+        if (!token) {
+            throw new Error();
         }
+        await new TokenService().removeToken(token);
     })
+    .withMessage("Invalid Token!")
+    ]
 )

--- a/src/middlewares/remove.token.ts
+++ b/src/middlewares/remove.token.ts
@@ -1,0 +1,12 @@
+import { header } from "express-validator"
+import TokenService from "../service/TokenService"
+import { verify } from "jsonwebtoken";
+
+export const removeToken = () => (
+    header('authorization').isJWT().custom(async value => {
+        const token = new TokenService().getToken(value);
+        if (token) {
+            new TokenService().removeToken(token);
+        }
+    })
+)

--- a/src/middlewares/remove.token.ts
+++ b/src/middlewares/remove.token.ts
@@ -1,8 +1,8 @@
-import { header } from "express-validator"
+import { query } from "express-validator"
 import TokenService from "../service/TokenService"
 
 export const removeToken = () => (
-    [header('authorization').isJWT().custom(async value => {
+    [query('authorization').isJWT().custom(async value => {
         const { token } = await new TokenService().getToken(value);
         if (!token) {
             throw new Error();

--- a/src/router/user.route.ts
+++ b/src/router/user.route.ts
@@ -2,9 +2,12 @@ import { Router } from "express";
 import UserController from "../controller/UserController";
 import { handleError } from "../middlewares/validation.result";
 import { userFields } from "../middlewares/user.fields";
+import { removeToken } from "../middlewares/remove.token";
 
 const router = Router();
 
 router.post('/users/new-user', userFields(), handleError, new UserController().newUser);
+
+router.post('/users/confirm-email', removeToken(), handleError);
 
 export default router;

--- a/src/router/user.route.ts
+++ b/src/router/user.route.ts
@@ -8,6 +8,6 @@ const router = Router();
 
 router.post('/users/new-user', userFields(), handleError, new UserController().newUser);
 
-router.post('/users/confirm-email', removeToken(), handleError);
+router.post('/users/confirm-email', removeToken(), handleError, new UserController().confirmEmail);
 
 export default router;

--- a/src/service/TokenService.ts
+++ b/src/service/TokenService.ts
@@ -21,5 +21,9 @@ export default class TokenService {
         )
     }
 
+    public async removeToken(token: string): Promise<void> {
+        await this.tokenRepository.delete({ token })
+    }
+
 
 }

--- a/src/utils/email.config.ts
+++ b/src/utils/email.config.ts
@@ -18,7 +18,7 @@ export const mail = (userEmail: string, userName: string, token: string) => {
         from: process.env.MAIL_USERNAME,
         to: userEmail,
         subject: 'Confirmação seu e-mail de cadastro',
-        html: `<h2>Olá, ${userName}!</h2><p>Para a sua segurança, confirme se este é o endereço de e-mail que você cadastrou no Payment Service.</p><p>Clique no link abaixo</p><a href="https://localhost:3002/confirm-email/${token}">${token}</a> `
+        html: `<h2>Olá, ${userName}!</h2><p>Para a sua segurança, confirme se este é o endereço de e-mail que você cadastrou no Payment Service.</p><p>Clique no link abaixo:</p><a href="https://localhost:3002/confirm-email/${token}">${token}</a> `
     })
 }
 


### PR DESCRIPTION
Ao realizar o cadastro com todas as informações corretas, como podemos ver pelo print abaixo:
![image](https://github.com/joaogabriellyra/payment-service/assets/77704693/422a60fe-eba3-46cd-8bca-b02ef9497df6)

O usuário receberá um e-mail informando que o cadastro foi realizado mas que é necessário confirmar o e-mail utilizado para cadastro e dentro do e-mail contém um link para o cliente clicar e realizar a confirmação sem nenhum outro passo além do clique inicial.  Segue print abaixo mostrando o e-mail: 
![image](https://github.com/joaogabriellyra/payment-service/assets/77704693/fa2f626e-8b69-4f1f-bfb2-2bf084bd949d)

Utilizando o Swagger como demonstrativo, veremos o fluxo de sucesso de confirmação de e-mail com o print abaixo:
![image](https://github.com/joaogabriellyra/payment-service/assets/77704693/ac1c7e2e-50e4-4d8f-aa8f-cb3e5d30e113)
