### PR TITLE
adicionado campo que informa se o e-mail foi confirmado

### DIFF
--- a/src/database/entity/User.ts
+++ b/src/database/entity/User.ts
@@ -23,6 +23,9 @@ import {
   
     @Column()
     password: string;
+
+    @Column()
+    confirmed: boolean;
   
     @CreateDateColumn()
     createdAt: Date;


### PR DESCRIPTION
Adicionei falso como valor padrão no campo que informa se o usuário foi confirmado tendo em vista que todo usuário recém cadastrado constará como não confirmado, precisando confirmar via e-mail recebido em e-mail utilizado no cadastro e através dessa confirmação o valor do campo confirmado será alterado.